### PR TITLE
Fix refresh token storage ttl

### DIFF
--- a/src/shared/redis/token-redis.service.ts
+++ b/src/shared/redis/token-redis.service.ts
@@ -5,7 +5,10 @@ import Redis from 'ioredis';
 export class TokenRedisService {
   constructor(@Inject('REDIS_CLIENT') private readonly redis: Redis) {}
 
-  async storeRefreshToken(userId: string, token: string, ttl = 7 * 24 * 60 * 60): Promise<void> {
+  // The refresh token itself is valid for 14 days, therefore
+  // we keep the value in Redis for the same amount of time to
+  // prevent valid tokens from being removed prematurely.
+  async storeRefreshToken(userId: string, token: string, ttl = 14 * 24 * 60 * 60): Promise<void> {
     await this.redis.set(`refresh:${userId}`, token, 'EX', ttl);
   }
 


### PR DESCRIPTION
## Summary
- keep refresh tokens in Redis for 14 days to match JWT expiration

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_683fb0033a5083288ea459c23f15d44b